### PR TITLE
clickreviews/cr_desktop: fix check on icon extension

### DIFF
--- a/clickreviews/cr_desktop.py
+++ b/clickreviews/cr_desktop.py
@@ -849,11 +849,11 @@ class ClickReviewDesktop(ClickReview):
                 link = 'http://askubuntu.com/questions/417369/what-does-desktop-icon-mean/417370'
             elif not os.path.exists(os.path.join(self.unpack_dir,
                                                  de.getIcon())) and \
-                    True not in filter(lambda a:
-                                       os.path.exists(os.path.join(
-                                                      self.unpack_dir,
-                                                      de.getIcon() + a)),
-                                       ICON_SUFFIXES):
+                    not any(map(lambda a:
+                                os.path.exists(os.path.join(
+                                               self.unpack_dir,
+                                               de.getIcon() + a)),
+                                ICON_SUFFIXES)):
                 t = 'error'
                 s = "'%s' specified as icon in .desktop file for app '%s', " \
                     "which is not available in the click package." % \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+click-reviewers-tools (0.51+ubports1) xenial; urgency=medium
+
+  * Fix check on icon extensions
+
+ -- Alberto Mardegan <mardy@users.sourceforge.net>  Sun, 16 Aug 2020 23:44:21 +0300
+
 click-reviewers-tools (0.50) unstable; urgency=medium
 
   * Added 16.04 framework for apparmor checks


### PR DESCRIPTION
The check was failing even if a file with the supported extension
existed. To fix it, use a combination of map() and any(): the former
maps the list of the icon extensions to a boolean telling if an icon
with that extension was found; the latter is used to check if any of
these checks returned true.